### PR TITLE
pr

### DIFF
--- a/conf/allPapersFetch.json
+++ b/conf/allPapersFetch.json
@@ -1,8 +1,8 @@
 {
 
-  "range": {
-    "begin": 2015,
-    "end": 2015
+  "first_range": {
+    "begin": 2016,
+    "end": 2016
   },
 
   "article_type": "research",
@@ -12,8 +12,8 @@
   ],
 
   "interval": {
-    "paper_crawler_interval_day": 60,
-    "detail_crawler_interval_day": 20
+    "paper_crawler_interval_day": 20,
+    "detail_crawler_interval_day": 10
   },
 
   "order": "date_desc"

--- a/src/main/java/com/weapes/ntpaprseng/crawler/crawler/DetailCrawler.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/crawler/DetailCrawler.java
@@ -1,7 +1,5 @@
 package com.weapes.ntpaprseng.crawler.crawler;
 
-import com.sun.rmi.rmid.ExecPermission;
-import com.sun.xml.internal.ws.api.message.ExceptionHasMessage;
 import com.weapes.ntpaprseng.crawler.log.Log;
 import com.weapes.ntpaprseng.crawler.util.Helper;
 
@@ -10,7 +8,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.DAYS;
 
 
 /**

--- a/src/main/java/com/weapes/ntpaprseng/crawler/crawler/DetailCrawler.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/crawler/DetailCrawler.java
@@ -1,5 +1,8 @@
 package com.weapes.ntpaprseng.crawler.crawler;
 
+import com.sun.rmi.rmid.ExecPermission;
+import com.sun.xml.internal.ws.api.message.ExceptionHasMessage;
+import com.weapes.ntpaprseng.crawler.log.Log;
 import com.weapes.ntpaprseng.crawler.util.Helper;
 
 import java.util.concurrent.ExecutorService;
@@ -8,6 +11,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.DAYS;
+
 
 /**
  * Created by lawrence on 16/8/16.
@@ -30,17 +34,24 @@ public class DetailCrawler implements Crawler {
 
     @Override
     public void crawl() {
-        //更新指标时间间隔
-        final int interval_day = Helper.getDetailCrawlerInterval();
-        //启动后延迟时间为0，间隔为interval_day，时间单位为minute，调整参数可以改变线程执行策略
-        Helper.loadMetricsLinks().forEach(paper ->
-                CREATOR.scheduleAtFixedRate(new StorableFetcher<>(CREATOR, CONSUMER, paper),
-                        0, interval_day, TimeUnit.MINUTES));
-
         try {
-            CREATOR.awaitTermination(1, DAYS);
+            System.out.print("开始更新指标。系统时间： " + Helper.getCrawlTime() + "\n");
+            System.out.print("本次待更新指标的论文总量为： " + Helper.getRefDataNum() + "\n");
+            Log.getRefNumbers().set(Helper.getRefDataNum());
+            //更新指标时间间隔
+            final int interval_day = Helper.getDetailCrawlerInterval();
+            //启动后延迟时间为0，间隔为interval_day，时间单位为minute，调整参数可以改变线程执行策略
+            Helper.loadMetricsLinks().forEach(paper ->
+                    CREATOR.scheduleAtFixedRate(new StorableFetcher<>(CREATOR, CONSUMER, paper),
+                            0, interval_day, TimeUnit.MINUTES));
+        }catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            CREATOR.awaitTermination(3, TimeUnit.DAYS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
     }
+
 }

--- a/src/main/java/com/weapes/ntpaprseng/crawler/crawler/PaperCrawler.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/crawler/PaperCrawler.java
@@ -38,6 +38,7 @@ class PaperCrawler implements Crawler {
             // 种子解析为followable
             // 对每个种子,交给生产者处理为Storable.
 
+            System.out.print("爬虫运行。系统时间：" + Helper.getCrawlTime() + "\n");
             //定时爬取间隔
             final int interval_day = Helper.getPaperCrawlerInterval();
             //启动后延迟时间为0，间隔为interval_day，时间单位为minute，调整参数可以改变线程执行策略
@@ -46,11 +47,11 @@ class PaperCrawler implements Crawler {
 
             LOGGER.info("种子分发完成...");
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         try {
-            CREATOR.awaitTermination(1, TimeUnit.DAYS);
+            CREATOR.awaitTermination(3, TimeUnit.DAYS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/weapes/ntpaprseng/crawler/crawler/StorableFetcher.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/crawler/StorableFetcher.java
@@ -5,6 +5,7 @@ import com.weapes.ntpaprseng.crawler.extract.ExtractedObject;
 import com.weapes.ntpaprseng.crawler.follow.Followable;
 import com.weapes.ntpaprseng.crawler.follow.Link;
 import com.weapes.ntpaprseng.crawler.store.Storable;
+import com.weapes.ntpaprseng.crawler.util.Helper;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/com/weapes/ntpaprseng/crawler/extract/PaperWebPage.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/extract/PaperWebPage.java
@@ -56,7 +56,7 @@ public class PaperWebPage extends WebPage {
     @Override
     public Storable extract() {
 
-        System.out.println("StoreObj parsing: type=PaperWebPage");
+        System.out.println("Webpage extracting: page_url=" + getUrl() + " type = PaperWebPage");
 
         final Document dom = Jsoup.parse(getText());
 

--- a/src/main/java/com/weapes/ntpaprseng/crawler/log/Log.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/log/Log.java
@@ -7,11 +7,18 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class Log {
     //单次爬取论文总量
-    private static final AtomicInteger URL_NUMBERS = new AtomicInteger();
+    private static AtomicInteger URL_NUMBERS = new AtomicInteger();
     //目前正在爬取的第几篇论文
     private static final AtomicInteger CRAWLING_NUMBERS = new AtomicInteger();
     //单次爬取成功数量
     private static final AtomicInteger CRAWLING_SUCCEED_NUMBERS = new AtomicInteger();
+
+    //单次更新指标论文总量
+    private static AtomicInteger REF_NUMBERS = new AtomicInteger();
+    //目前正在更新的第几篇论文
+    private static final AtomicInteger REFRESHING_NUMBERS = new AtomicInteger();
+    //单次更新成功数量
+    private static final AtomicInteger REFRESHINGING_SUCCEED_NUMBERS = new AtomicInteger();
 
     private static String LAST_LINK;
 
@@ -33,6 +40,15 @@ public class Log {
 
     public static AtomicInteger getCrawlingSucceedNumbers() {
         return CRAWLING_SUCCEED_NUMBERS;
+    }
+
+    public static AtomicInteger getRefNumbers() { return REF_NUMBERS;
+    }
+    public static AtomicInteger getRefreshingNumbers() {
+        return REFRESHING_NUMBERS;
+    }
+    public static AtomicInteger getRefreshingingSucceedNumbers() {
+        return REFRESHINGING_SUCCEED_NUMBERS;
     }
 
 }

--- a/src/main/java/com/weapes/ntpaprseng/crawler/store/MetricsPaper.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/store/MetricsPaper.java
@@ -6,9 +6,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import static com.weapes.ntpaprseng.crawler.log.Log.getCrawlingSucceedNumbers;
-import static com.weapes.ntpaprseng.crawler.log.Log.getLastLink;
-import static com.weapes.ntpaprseng.crawler.log.Log.getUrlNumbers;
+import static com.weapes.ntpaprseng.crawler.log.Log.*;
 import static com.weapes.ntpaprseng.crawler.util.Helper.getLogger;
 
 /**
@@ -197,13 +195,13 @@ public class MetricsPaper implements Storable{
                 // 判断执行是否成功
                 boolean succeed = preparedStatement.executeUpdate() != 0;
                 if (succeed) {
-                    LOGGER.info("第" + getCrawlingSucceedNumbers().incrementAndGet() + "篇论文相关指标更新成功...\n"
+                    LOGGER.info("第" + getRefreshingingSucceedNumbers().incrementAndGet() + "篇论文相关指标更新成功...\n"
                             + "链接为；" + getUrl());
                 }
-                if (getLastLink().equals(getUrl())) {
-                    LOGGER.info("更新完成，本次更新相关指标论文总量：" + getUrlNumbers().get()
-                            + " 成功数：" + getCrawlingSucceedNumbers().get()
-                            + " 失败数：" + (getUrlNumbers().get() - getCrawlingSucceedNumbers().get()));
+                if (getRefreshingingSucceedNumbers().get() == getRefNumbers().get()) {
+                    LOGGER.info("更新完成，本次更新相关指标论文总量：" + getRefNumbers().get()
+                            + " 成功数：" + getRefreshingingSucceedNumbers().get()
+                            + " 失败数：" + (getRefNumbers().get() - getRefreshingingSucceedNumbers().get()));
                 }
                 return succeed;
             }

--- a/src/main/java/com/weapes/ntpaprseng/crawler/store/Paper.java
+++ b/src/main/java/com/weapes/ntpaprseng/crawler/store/Paper.java
@@ -1,5 +1,7 @@
 package com.weapes.ntpaprseng.crawler.store;
 
+import com.weapes.ntpaprseng.crawler.log.Log;
+import com.weapes.ntpaprseng.crawler.util.Helper;
 import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 
@@ -9,7 +11,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import static com.weapes.ntpaprseng.crawler.log.Log.*;
-import static com.weapes.ntpaprseng.crawler.util.Helper.getLogger;
+import static com.weapes.ntpaprseng.crawler.util.Helper.*;
 
 /**
  * 论文Model
@@ -150,7 +152,6 @@ public class Paper implements Storable {
     @Override
     public boolean store() {
         System.out.println("Store begin: type=Paper");
-
         final HikariDataSource mysqlDataSource =
                 DataSource.getMysqlDataSource();
 
@@ -163,9 +164,10 @@ public class Paper implements Storable {
                         connection.prepareStatement(NT_PAPERS_INSERT_SQL);
                 bindPaperSQL(paperPreparedStatement);
                 System.out.println("sql exeing");
-                // 判断执行是否成功
+                // 判断爬取论文信息操作是否成功
                 isSucceed = paperPreparedStatement.executeUpdate() != 0;
             } catch (SQLException e) {
+                isSucceed = false;
             }
 
             try {
@@ -173,7 +175,7 @@ public class Paper implements Storable {
                         connection.prepareStatement(REF_INSERT_SQL);
                 bindRefSQL(refPreparedStatement);
                 System.out.println("store metrix url to  REF_DATA");
-                isSucceed = refPreparedStatement.executeUpdate() != 0;
+                refPreparedStatement.executeUpdate();
             } catch (SQLException e) {
             }
 
@@ -187,6 +189,10 @@ public class Paper implements Storable {
                         + " 失败数：" + (getUrlNumbers().get() - getCrawlingSucceedNumbers().get()));
             }
 
+            //更新爬取检查状态参数
+            Helper.isFirstCrawl = false;
+            isDesided = false;
+            isFirstPaperLink = true;
             return isSucceed;
         } catch (SQLException e) {
         }


### PR DESCRIPTION
10 files committed: 第一部分实现了较为完整实现了定时检查爬取，获取当次爬取论文总数 考虑到在周期性爬取等待期间程序突然终止的突发情况的处理（即重启后不必要全部再爬取） 由于此修改是针对实际使用时程序是默认一直执行的（周期性爬取），所以如果以后各位测试时如果一次数据没有爬取完就终止程序，重启程序后是默认认为上次的所有论文已经爬取完了的（这就是上述的突发情况的处理方式），所以第一部分，测试时每一次启动程序前需要将第一张数据表清空才能正常爬取 当然 另外 程序在爬虫执行时突然终止（如断电）的突发情况没有解决。。 另外 第二部分获取了当次更新指标的论文数量，以备日志使用，也实现了部分日志。